### PR TITLE
Fix OAMADDR clearing at incorrect PPU ticks

### DIFF
--- a/src/ppu.c
+++ b/src/ppu.c
@@ -80,9 +80,7 @@ void update_ppu(ppu_t *ppu) {
     }
 
     // Clear OAMADDR
-    if ((ppu->scanline < PPU_SCANLINE_IDLE ||
-         ppu->scanline == PPU_SCANLINE_PRERENDER) &&
-        ppu->dot >= 257 && ppu->dot <= 320) {
+    if (is_rendering_ppu(ppu) && ppu->dot >= 257 && ppu->dot <= 320) {
         ppu->oam_addr = 0;
     }
 

--- a/tests/src/ppu-test.c
+++ b/tests/src/ppu-test.c
@@ -10,10 +10,10 @@ int tests_run = 0;
 static char *test_blargg_ppu_vbl_nmi() {
     const char *test_roms[13] = {
         "../roms/ppu_open_bus/ppu_open_bus.nes",
-
-        // TODO: Debug
         "../roms/oam_read/oam_read.nes",
         "../roms/oam_stress/oam_stress.nes",
+
+        // TODO: Debug
         "../roms/ppu_vbl_nmi/01-vbl_basics.nes",
         "../roms/ppu_vbl_nmi/02-vbl_set_time.nes",
         "../roms/ppu_vbl_nmi/03-vbl_clear_time.nes",
@@ -33,7 +33,7 @@ static char *test_blargg_ppu_vbl_nmi() {
     unsigned char status = 0;
     char result[2048] = {0};
 
-    for (unsigned i = 0; i < 1; i++) {
+    for (unsigned i = 0; i < 3; i++) {
         emulator_t emu;
         create_emulator(&emu, test_roms[i]);
 


### PR DESCRIPTION
* Only clear OAMADDR if the PPU is in the rendering state